### PR TITLE
stm32: read the n32g45x unique id from its documented address

### DIFF
--- a/src/stm32/internal.h
+++ b/src/stm32/internal.h
@@ -24,6 +24,13 @@
 #include "stm32l4xx.h"
 #endif
 
+#if CONFIG_MACH_N32G45x
+// The n32g45x builds against the stm32f103 headers, but it stores its
+// 96bit unique device id at a different address
+#undef UID_BASE
+#define UID_BASE 0x1FFFF7F0UL
+#endif
+
 // gpio.c
 GPIO_TypeDef *gpio_pin_to_regs(uint32_t pin);
 #define GPIO(PORT, NUM) (((PORT)-'A') * 16 + (NUM))


### PR DESCRIPTION
**Draft — do not merge before the companion Katapult PR and hardware verification. See "Breaking change" below.**

Stacked on #7347 (base branch `n32g45x-usb-fix`) — this is a separate, more invasive change and I want it reviewable on its own.

## What this does

The n32g45x reuses the stm32f103xe headers and therefore inherits `UID_BASE = 0x1FFFF7E8`. Per the N32G45x system-config-block map, that address only covers the last 4 of the 12 bytes `chipid.c` reads as the "unique ID" — the other 8 bytes come from an undocumented region of the system block, not the documented 96-bit UID (which starts at `0x1FFFF7F0`). Override `UID_BASE` for `CONFIG_MACH_N32G45x` so the full 96-bit UID is used.

## Why this is a draft, not a normal PR

- **I can't confirm the 8 undocumented bytes are safe to drop.** If they're chip-unique (die coordinates, lot number), the current code is fine as-is and this patch is unnecessary. If they're a fixed constant, CAN UUID uniqueness today rests entirely on the last 4 bytes. No collisions have been reported, so this is a *suspected* gap, not a confirmed bug. Five minutes with real hardware — reading `0x1FFFF7E8` on two boards and diffing — would settle it.
- **This is a breaking change for any board already running Klipper on n32g45x.** The CAN UUID and USB serial number both change. `canbus_uuid` in `printer.cfg` will need updating, and any `/dev/serial/by-id/...` udev rule keyed on the old serial breaks too.
- **Klipper and Katapult must be reflashed together.** Until both sides carry this change, the bootloader-reported UUID and the app-reported UUID won't match, and `flashtool.py -u ... -r` (UUID-based reflash) won't find the device. Companion PR: https://github.com/loss-and-quick/katapult/pull/1.

## Testing

Compiled a standalone probe with the real build flags: `UID_BASE` resolves to `0x1FFFF7F0` under `MACH_N32G452`, and is unchanged at `0x1FFFF7E8` under `MACH_STM32F103`. No other code references `UID_BASE`, so the diff is confined to this one macro.
